### PR TITLE
[REQ-04-10][FUN-092] 팀 등록을 위한 본부, 담당, 팀 조회 API

### DIFF
--- a/src/main/java/kr/co/iabacus/sales/web/team/controller/TeamController.java
+++ b/src/main/java/kr/co/iabacus/sales/web/team/controller/TeamController.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
@@ -17,7 +18,7 @@ import kr.co.iabacus.sales.web.team.service.TeamService;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/teams")
+@RequestMapping("/api/v1")
 public class TeamController {
 
     private final TeamService teamService;
@@ -30,6 +31,25 @@ public class TeamController {
     @GetMapping("/tree-view")
     public ResponseEntity<Map<String, Map<String, List<TeamResponse>>>> getTeamTreeView() {
         return ResponseEntity.ok(teamService.getTeamTreeView());
+    }
+
+    @GetMapping("/headquarters")
+    public ResponseEntity<List<String>> getHeadquarters() {
+        List<String> headquartersList = teamService.getDistinctHeadquarters();
+        return ResponseEntity.ok(headquartersList);
+    }
+
+    @GetMapping("/manage-part")
+    public ResponseEntity<List<String>> getManagePart(@RequestParam String headquarters) {
+        List<String> managePartList = teamService.getDistinctManagePartsByHeadquarters(headquarters);
+        return ResponseEntity.ok(managePartList);
+    }
+
+    @GetMapping("/teams")
+    public ResponseEntity<List<String>> getTeams(@RequestParam String headquarters,
+                                               @RequestParam("manage-part") String managePart) {
+        List<String> teamList = teamService.getTeamsByHeadquartersAndDepartment(headquarters, managePart);
+        return ResponseEntity.ok(teamList);
     }
 
 }

--- a/src/main/java/kr/co/iabacus/sales/web/team/repository/TeamRepository.java
+++ b/src/main/java/kr/co/iabacus/sales/web/team/repository/TeamRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import kr.co.iabacus.sales.web.team.domain.Team;
 
@@ -16,6 +17,16 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     Optional<Team> findByName(String name);
 
     @Query("SELECT t FROM Team t WHERE t.isActivated = true")
+
     List<Team> findAllIsActivatedTrue();
+    @Query("SELECT DISTINCT t.headquarters FROM Team t WHERE t.isActivated = true")
+    List<String> findDistinctHeadquarters();
+
+    @Query("SELECT DISTINCT t.managePart FROM Team t WHERE t.headquarters = :headquarters AND t.isActivated = true")
+    List<String> findDistinctManagePartsByHeadquarters(@Param("headquarters") String headquarters);
+
+    @Query("SELECT t.name FROM Team t WHERE t.headquarters = :headquarters AND t.managePart = :managePart AND t.isActivated = true")
+    List<String> findTeamNamesByHeadquartersAndManagePart(@Param("headquarters") String headquarters,
+                                                          @Param("managePart") String managePart);
 
 }

--- a/src/main/java/kr/co/iabacus/sales/web/team/service/TeamService.java
+++ b/src/main/java/kr/co/iabacus/sales/web/team/service/TeamService.java
@@ -46,4 +46,17 @@ public class TeamService {
         }
     }
 
+
+    public List<String> getDistinctHeadquarters() {
+        return teamRepository.findDistinctHeadquarters();
+    }
+
+    public List<String> getDistinctManagePartsByHeadquarters(String headquarters) {
+        return teamRepository.findDistinctManagePartsByHeadquarters(headquarters);
+    }
+
+    public List<String> getTeamsByHeadquartersAndDepartment(String headquarters, String managePart) {
+        return teamRepository.findTeamNamesByHeadquartersAndManagePart(headquarters, managePart);
+    }
+
 }


### PR DESCRIPTION
## 이슈 번호
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #90 


## 설명
<!--- 작업 내용에 대한 설명을 적어주세요 -->
구성원에 팀 등록 시 본부-> 담당-> 팀을 순서대로 등록하기 위해 필요한 조회 API를 구현하였습니다.


## 테스트 결과
<!--- 테스트를 어떻게 진행했는지 작성해주세요 -->
<!--- 어떤 영향을 끼치는지 작성해주세요 -->


## 스크린샷
<!-- 테스트 결과 캡쳐를 첨부해주세요 ex) postman -->
![image](https://github.com/user-attachments/assets/97aab147-3148-4f49-9348-e34a2ccbccc0)

![image](https://github.com/user-attachments/assets/38cae0d6-e052-4379-a4f9-f25acf04f666)

![image](https://github.com/user-attachments/assets/7289c3a8-c0cb-4e0b-9ca8-c2e4c9fb7b91)

